### PR TITLE
Log ffmpeg output to a configured file

### DIFF
--- a/Broadcaster/AbstractSchedulerCommands.php
+++ b/Broadcaster/AbstractSchedulerCommands.php
@@ -14,7 +14,7 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
     const METADATA_CHANNEL = 'channel_id';
     const METADATA_ENVIRONMENT = 'env';
     const METADATA_MONITOR = 'monitor_stream';
-    const LOG_FILE = '%s_ffmpeg_log.txt';
+    const LOG_FILE = 'livebroadcaster-ffmpeg-%s.log';
 
     /**
      * Symfony kernel environment name
@@ -139,7 +139,7 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
 
         if (!empty($this->logDirectoryFFMpeg)) {
             $now = new \DateTime();
-            $logFile = $this->logDirectoryFFMpeg.DIRECTORY_SEPARATOR.sprintf(self::LOG_FILE, $now->format(\DateTime::ISO8601));
+            $logFile = $this->logDirectoryFFMpeg.DIRECTORY_SEPARATOR.sprintf(self::LOG_FILE, $now->format('Y-m-d_His'));
         }
 
         return exec(sprintf('ffmpeg %s %s%s >%s 2>&1 &', $input, $output, $meta, $logFile));

--- a/Broadcaster/AbstractSchedulerCommands.php
+++ b/Broadcaster/AbstractSchedulerCommands.php
@@ -14,6 +14,7 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
     const METADATA_CHANNEL = 'channel_id';
     const METADATA_ENVIRONMENT = 'env';
     const METADATA_MONITOR = 'monitor_stream';
+    const LOG_FILE = '%s_ffmpeg_log.txt';
 
     /**
      * Symfony kernel environment name
@@ -21,6 +22,13 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
      * @var string
      */
     protected $kernelEnvironment;
+
+    /**
+     * Directory to store FFMpeg logs
+     *
+     * @var string
+     */
+    protected $logDirectoryFFMpeg = '';
 
     /**
      * SchedulerCommands constructor.
@@ -127,7 +135,14 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
      */
     protected function execStreamCommand($input, $output, $meta)
     {
-        return exec(sprintf('ffmpeg %s %s%s >/dev/null 2>&1 &', $input, $output, $meta));
+        $logFile = '/dev/null';
+
+        if (!empty($this->logDirectoryFFMpeg)) {
+            $now = new \DateTime();
+            $logFile = $this->logDirectoryFFMpeg.DIRECTORY_SEPARATOR.sprintf(self::LOG_FILE, $now->format(\DateTime::ISO8601));
+        }
+
+        return exec(sprintf('ffmpeg %s %s%s >%s 2>&1 &', $input, $output, $meta, $logFile));
     }
 
     /**
@@ -166,5 +181,17 @@ abstract class AbstractSchedulerCommands implements SchedulerCommandsInterface
         }
 
         return;
+    }
+
+    /**
+     * @param string $directory
+     */
+    public function setFFMpegLogDirectory($directory)
+    {
+        if (!is_writable($directory)) {
+            return;
+        }
+
+        $this->logDirectoryFFMpeg = $directory;
     }
 }

--- a/Broadcaster/SchedulerCommandsDetector.php
+++ b/Broadcaster/SchedulerCommandsDetector.php
@@ -16,20 +16,28 @@ class SchedulerCommandsDetector
      * Create the class required for scheduler commands.
      *
      * @param string $environment
+     * @param string $ffmpegLogDirectory
      *
      * @return SchedulerCommandsInterface
      */
-    public static function createSchedulerCommands($environment)
+    public static function createSchedulerCommands($environment, $ffmpegLogDirectory)
     {
         $osCode = strtoupper(substr(PHP_OS, 0, 3));
 
         switch ($osCode) {
             case 'WIN':
-                return new WindowsCommands($environment);
+                $schedulerCommands = new WindowsCommands($environment);
+                break;
             case 'DAR':
-                return new MacCommands($environment);
+                $schedulerCommands = new MacCommands($environment);
+                break;
             default:
-                return new LinuxCommands($environment);
+                $schedulerCommands = new LinuxCommands($environment);
+                break;
         }
+
+        $schedulerCommands->setFFMpegLogDirectory($ffmpegLogDirectory);
+
+        return $schedulerCommands;
     }
 }

--- a/Broadcaster/SchedulerCommandsInterface.php
+++ b/Broadcaster/SchedulerCommandsInterface.php
@@ -67,4 +67,9 @@ interface SchedulerCommandsInterface
      * @return string
      */
     public function getKernelEnvironment();
+
+    /**
+     * @param string $directory
+     */
+    public function setFFMpegLogDirectory($directory);
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('redirect_route')->defaultNull()->end()
                     ->end()
                 ->end()
+                ->arrayNode('ffmpeg')
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('log_directory')->defaultNull()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/LiveBroadcastExtension.php
+++ b/DependencyInjection/LiveBroadcastExtension.php
@@ -33,5 +33,7 @@ class LiveBroadcastExtension extends Extension
         $container->setParameter('livebroadcast.yt.clientid', $config['youtube']['client_id']);
         $container->setParameter('livebroadcast.yt.clientsecret', $config['youtube']['client_secret']);
         $container->setParameter('livebroadcast.yt.redirectroute', $config['youtube']['redirect_route']);
+
+        $container->setParameter('livebroadcast.ffmpeg.logdirectory', $config['ffmpeg']['log_directory']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage should be limited to development work.*
 # About
 
 The Live Broadcast Bundle will make it possible to plan live video streams to
-various channels like Twitch, YouTube Live and Facebook Live (referred to as Output or Channels).
+various channels like Twitch, YouTube Live, Facebook Live, UStream and Live.Ly (referred to as Output or Channels).
 
 The basic "Input" will be a file or URL that will be streamed. Other inputs will be created thereafter.
 
@@ -111,6 +111,13 @@ Create a Facebook app on https://developers.facebook.com with the following perm
     twig:
         globals:
             live_broadcast_facebook_app_id: 'YourFacebookAppId'
+
+### FFMpeg log directory
+To view the output of FFMpeg you need to configure a log directory in your `app/config/config.yml`.
+ 
+     live_broadcast:
+        ffmpeg:
+            log_directory: '%kernel.logs_dir%'
 
 ## Enabling YouTube Live
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,6 +4,7 @@ services:
       factory: [Martin1982\LiveBroadcastBundle\Broadcaster\SchedulerCommandsDetector, createSchedulerCommands]
       arguments:
           - "%kernel.environment%"
+          - "%livebroadcast.ffmpeg.logdirectory%"
 
   live.broadcast.scheduler:
       class: Martin1982\LiveBroadcastBundle\Broadcaster\Scheduler

--- a/Tests/Broadcaster/SchedulerCommandsTest.php
+++ b/Tests/Broadcaster/SchedulerCommandsTest.php
@@ -32,6 +32,26 @@ class SchedulerCommandsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the start process command with a log directory configured
+     */
+    public function testStartProcessWithLogDirectory()
+    {
+        $command = new SchedulerCommands('unittest');
+        $command->setFFMpegLogDirectory('/tmp');
+
+        $exec = $this->getFunctionMock('Martin1982\LiveBroadcastBundle\Broadcaster', 'exec');
+        $exec->expects($this->once())->willReturnCallback(
+            function ($command) {
+                // @codingStandardsIgnoreLine
+                $now = new \DateTime();
+                self::assertEquals('ffmpeg input output -metadata broadcast_id=12 -metadata test=unit -metadata env=unittest >/tmp/livebroadcaster-ffmpeg-'.$now->format('Y-m-d_His').'.log 2>&1 &', $command);
+            }
+        );
+
+        $command->startProcess('input', 'output', array('broadcast_id' => 12, 'test' => 'unit'));
+    }
+
+    /**
      * Test the stop process command.
      */
     public function testStopProcess()

--- a/Tests/Broadcaster/SchedulerCommandsTest.php
+++ b/Tests/Broadcaster/SchedulerCommandsTest.php
@@ -42,8 +42,8 @@ class SchedulerCommandsTest extends \PHPUnit_Framework_TestCase
         $exec = $this->getFunctionMock('Martin1982\LiveBroadcastBundle\Broadcaster', 'exec');
         $exec->expects($this->once())->willReturnCallback(
             function ($command) {
-                // @codingStandardsIgnoreLine
                 $now = new \DateTime();
+                // @codingStandardsIgnoreLine
                 self::assertEquals('ffmpeg input output -metadata broadcast_id=12 -metadata test=unit -metadata env=unittest >/tmp/livebroadcaster-ffmpeg-'.$now->format('Y-m-d_His').'.log 2>&1 &', $command);
             }
         );


### PR DESCRIPTION
Default behaviour is still the same, log to /dev/null if no log directory is configured or when the configured directory is not writable